### PR TITLE
chore: More standard installation via Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
+PREFIX ?= /usr/local
+BIN ?= csv_to_mdtable
+
 csv_to_mdtable:
 	crystal build --release csv_to_mdtable.cr
 
 build : csv_to_mdtable
 
 install: csv_to_mdtable
-	mv csv_to_mdtable ~/bin/
+	mv csv_to_mdtable $(PREFIX)/bin/$(BIN)
+
+uninstall: csv_to_mdtable
+	mv csv_to_mdtable $(PREFIX)/bin/$(BIN)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,29 @@
 # Install
 
-If `~/bin` is in path:
+Installs to `/usr/local`
 
 ```
-make
+make install
 ```
+
+To specify a different location, from example `~/bin`
+
+```
+make PREFIX=$HOME install
+```
+
+Set BIN to customize the name of the executable:
+
+```
+make PREFIX=$HOME BIN=csvmd install
+```
+
+To remove the binary:
+
+```
+make PREFIX=$HOME BIN=csvmd uninstall
+```
+
 
 Otherwise
 


### PR DESCRIPTION
Makefile will now by default install to /usr/local instead of ~/bin.
This behavior can be change by supplying PREFIX.

See README.md for instructions